### PR TITLE
chore: simplify dependabot allow config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,3 @@ updates:
           - "playwright"
           - "sharp"
           - "zod"
-    # Allow both direct and indirect dependency updates
-    allow:
-      - dependency-type: "all"


### PR DESCRIPTION
## Summary
- remove the allow configuration that set dependency-type to all in dependabot settings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4f16562e48328bc024c201b25e137